### PR TITLE
Update .gitmodules to point to right repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/MQLib/MQLib
 [submodule "test-generators/KaGen"]
 	path = test-generators/KaGen
-	url = https://github.com/Amtrix/KaGen
+	url = https://github.com/KarlsruheGraphGeneration/KaGen


### PR DESCRIPTION
When building the project, the KaGen generator's repository pointed to a fork that no longer exists.
With this change, it points to the actual repository, which seems to be actively maintained https://github.com/KarlsruheGraphGeneration/KaGen